### PR TITLE
Add request body to Notice

### DIFF
--- a/notice.go
+++ b/notice.go
@@ -157,7 +157,7 @@ func NewNotice(e interface{}, ctx *gin.Context, depth int) *Notice {
 		notice.Context["component"] = packageName
 	}
 
-	if ctx.Request != nil {
+	if ctx != nil && ctx.Request != nil {
 		notice.SetRequest(ctx)
 	}
 

--- a/notifier.go
+++ b/notifier.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 const (
@@ -217,7 +219,7 @@ func (n *Notifier) AddFilter(fn func(*Notice) *Notice) {
 }
 
 // Notify notifies Airbrake about the error.
-func (n *Notifier) Notify(e interface{}, req *http.Request) {
+func (n *Notifier) Notify(e interface{}, ctx *gin.Context) {
 	if n.opt.DisableErrorNotifications {
 		logger.Printf(
 			"error notifications are disabled, will not deliver notice=%q",
@@ -226,14 +228,14 @@ func (n *Notifier) Notify(e interface{}, req *http.Request) {
 		return
 	}
 
-	notice := n.Notice(e, req, 1)
+	notice := n.Notice(e, ctx, 1)
 	n.SendNoticeAsync(notice)
 }
 
 // Notice returns Aibrake notice created from error and request. depth
 // determines which call frame to use when constructing backtrace.
-func (n *Notifier) Notice(err interface{}, req *http.Request, depth int) *Notice {
-	return NewNotice(err, req, depth+1)
+func (n *Notifier) Notice(err interface{}, ctx *gin.Context, depth int) *Notice {
+	return NewNotice(err, ctx, depth+1)
 }
 
 type sendResponse struct {

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -43,8 +44,8 @@ var _ = Describe("Notifier", func() {
 	var sentNotice *gobrake.Notice
 	var sendNoticeReq *http.Request
 
-	notify := func(e interface{}, req *http.Request) {
-		notifier.Notify(e, req)
+	notify := func(e interface{}, ctx *gin.Context) {
+		notifier.Notify(e, ctx)
 		notifier.Flush()
 	}
 
@@ -326,7 +327,11 @@ var _ = Describe("Notifier", func() {
 			},
 		}
 
-		notify("hello", req)
+		ginCtx := &gin.Context{
+			Request: req,
+		}
+
+		notify("hello", ginCtx)
 
 		ctx := sentNotice.Context
 		Expect(ctx["url"]).To(Equal("http://foo/bar"))

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Notifier", func() {
 		Expect(sentNotice.Context["rootDirectory"]).To(Equal(wd))
 		Expect(sentNotice.Context["gopath"]).To(Equal(gopath))
 		Expect(sentNotice.Context["component"]).To(Equal("github.com/airbrake/gobrake/v5_test"))
-		Expect(sentNotice.Context["repository"]).To(ContainSubstring("airbrake/gobrake"))
+		Expect(sentNotice.Context["repository"]).To(ContainSubstring("Tixologi-Inc/gobrake"))
 		Expect(sentNotice.Context["revision"]).NotTo(BeEmpty())
 		Expect(sentNotice.Context["lastCheckout"]).NotTo(BeEmpty())
 	})


### PR DESCRIPTION
Notice context now contains HTTP request body when method is POST, PUT or PATCH